### PR TITLE
fix(release-notes): Increase getMonth return

### DIFF
--- a/packages/release-notes/lib.js
+++ b/packages/release-notes/lib.js
@@ -50,7 +50,7 @@ async function findPackages(folder) {
 
 function getCurrDate() {
   const now = new Date();
-  return `${now.getFullYear()}-${now.getMonth() < 10 ? '0' : '0'}${now.getMonth()}-${now.getDate() < 10 ? '0' : ''}${now.getDate()}`;
+  return `${now.getFullYear()}-${(now.getMonth() + 1) < 10 ? '0' : ''}${now.getMonth() + 1}-${now.getDate() < 10 ? '0' : ''}${now.getDate()}`;
 }
 
 async function groupMessages(allPackages, { hash, message }) {


### PR DESCRIPTION
getMonth - `zero indicates the first month of the year` [(MDN here)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getMonth)

So, it has to be increased by 1.

Otherwise it causes this:

![image](https://user-images.githubusercontent.com/32869456/72616342-fe8ea580-3936-11ea-85b4-1255ac8ed3d6.png)


@karel-bot add_reviewer @karelhala 

cc @Hyperkid123