### PR TITLE
feat(analyzer): allow to set default release

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ after_success:
 
 ## Options
 
+### Patterns
+
 To change default patterns you can pass your own in your release option.
 ```JSON
 {
@@ -75,3 +77,41 @@ To change default patterns you can pass your own in your release option.
 ```
 
 Each pattern is transfered into Regular Expression and searched in each commit message.
+
+### defaultRelease
+
+Can be set to one of:
+
+```jsx
+['major', 'minor', 'patch'];
+```
+
+DefaultRelease is set to `patch`.
+
+```JSON
+{
+  "release": {
+    "analyzeCommits": [
+      {
+        "path": "@khala/commit-analyzer-wildcard/analyzer",
+        "defaultRelease": "major"
+      }
+    ]
+  }
+}
+```
+
+You can turn the releasing off by setting a value not included in the array:
+
+```JSON
+{
+  "release": {
+    "analyzeCommits": [
+      {
+        "path": "@khala/commit-analyzer-wildcard/analyzer",
+        "defaultRelease": "noRelease"
+      }
+    ]
+  }
+}
+```


### PR DESCRIPTION
- allows to set `defaultRelease`
- removes `prerelease` from types (it wasn't used at all, the type 3 has been always overwritten to 2)
- `noRelease` tag won't turn the whole releasing off anymore
Before this, any `noRelease` caused that there is no new version at all. I think this is not how it should work. Now, the 'highest' release tag has a priority.
- adds a log message for each commit to allow better understanding what's going on

@karelhala 

cc @Hyperkid123